### PR TITLE
npm キャッシュ活用

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,18 @@ jobs:
           key: composer-v1-{{ checksum "composer.lock" }}
           paths:
             - vendor
-      - run: npm ci
+      - restore_cache:
+          key: npm-v1-{{ checksum "package-lock.json" }}
+      - run:
+          name: npm ci
+          command: |
+            if [ ! -d node_modules ]; then
+              npm ci
+            fi 
+      - save_cache:
+          key: npm-v1-{{ checksum "package-lock.json" }}
+          paths:
+            - node_modules
       - run: npm run dev
       - run:
           name: php test


### PR DESCRIPTION
[修正]

cicleci/config.ymlファイルを修正しました。

■修正理由
自動テスト時に、毎回npm installすると時間がかかるので、
キャッシュを活用し、前回との差分がなければそのまま使用するように変更。